### PR TITLE
Open TMWIC.com in a new window / tab

### DIFF
--- a/src/scripts/contentscript.js
+++ b/src/scripts/contentscript.js
@@ -16,7 +16,7 @@ ext.runtime.sendMessage({}, function(response) {
       const threadSubscriptionStatus = document.getElementsByClassName("thread-subscription-status")[0];
 
       const openLink = function() {
-        window.location = "https://tellmewhenitcloses.com?url=" + location.href;
+        window.open("https://tellmewhenitcloses.com?url=" + location.href);
       };
 
       const tellMeWhenButton = document.createElement("button");


### PR DESCRIPTION
Currently the extension will navigate the current window away from
GitHub when users click on the "Tell Me When It Closes" button.

This change updates the behavior to open a new window/tab when a user
clicks on the "Tell Me When It Closes" button so that the context of the
GitHub issue is not lost.

This could be exposed as an option, although I'm generally in favor of
avoid configuration whenever we can. Also, I can see the argument for
sticking with the current behavior and letting cmd-click be the solution
for open in new tab, so please consider this more of a conversation starter
than a formal suggestion. That said, I did find the current behavior surprising
when I first tried the extension, so that was my reason for opening this PR.