### PR TITLE
Use a link to allow opening in new tab

### DIFF
--- a/src/scripts/contentscript.js
+++ b/src/scripts/contentscript.js
@@ -1,34 +1,42 @@
 import ext from "./utils/ext";
+import buildElement from "./utils/buildElement";
 
-const ID = "github-tellmewhenitcloses-button"
+const TMWIC_BUTTON_ID = "github-tellmewhenitcloses-button";
+const GITHUB_SUBSCRIPT_BUTTON_ID = "thread-subscription-status";
+const BUTTON_STYLES = "width: 100%; margin-bottom: 10px; text-align: center;";
 
 ext.runtime.sendMessage({}, function(response) {
   var readyStateCheckInterval = setInterval(function() {
     if (document.readyState === "complete") {
       clearInterval(readyStateCheckInterval);
 
-      const button = document.getElementById(ID)
+      const button = document.getElementById(TMWIC_BUTTON_ID);
 
       // Exit early if button already exists
       if (button !== null) { return }
 
       // Grab notification element on page
-      const threadSubscriptionStatus = document.getElementsByClassName("thread-subscription-status")[0];
+      const threadSubscriptionStatus =
+        document.getElementsByClassName(GITHUB_SUBSCRIPT_BUTTON_ID)[0];
 
-      const openLink = function() {
-        window.location = "https://tellmewhenitcloses.com?url=" + location.href;
-      };
+      const twmicUrl = "https://tellmewhenitcloses.com?url=" + location.href;
 
-      const tellMeWhenButton = document.createElement("button");
-      tellMeWhenButton.className = "btn btn-sm";
-      tellMeWhenButton.id = ID;
-      tellMeWhenButton.style.width = '100%';
-      tellMeWhenButton.style.marginBottom = '10px';
-      tellMeWhenButton.onclick = openLink;
-      tellMeWhenButton.innerText = "Tell Me When It Closes";
+      const tellMeWhenButton = buildElement(`
+        <a
+          id="${TMWIC_BUTTON_ID}"
+          class="btn btn-sm"
+          href="${twmicUrl}"
+          style="${BUTTON_STYLES}"
+        >
+          Tell Me When It Closes
+        </a>
+      `)
 
       // Stick button in-front of all child elements of notifications
-      threadSubscriptionStatus.parentNode.insertBefore(tellMeWhenButton, threadSubscriptionStatus.previousSibling);
+      threadSubscriptionStatus.parentNode.insertBefore(
+        tellMeWhenButton,
+        threadSubscriptionStatus.previousSibling
+      );
     }
   }, 10);
 });

--- a/src/scripts/utils/buildElement.js
+++ b/src/scripts/utils/buildElement.js
@@ -1,0 +1,5 @@
+export default function(markup) {
+  const div = document.createElement('div');
+  div.innerHTML = markup.trim();
+  return div.childNodes[0];
+}


### PR DESCRIPTION
Currently the extension uses a button to provide the "Tell Me When It
Closes" connection. While the button visually matches the GitHub UI,
using a button and JS `location.url = ...` to direct the user to
https://tellmewhenitcloses.com prevents the user from opening the page
in a new tab, should they want to.

This change updates to use a link instead of the current button.
Visually and functionally things are the same, but now users can opt to
cmd-click or shift-cmd-click to control how the page opens.